### PR TITLE
Migrate Provider Releases from TeamCity to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.go-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: go-version
+        run: echo "::set-output name=version::$(cat ./.go-version)"
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Generate Release Notes
+        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release-notes
+          path: release-notes.txt
+          retention-days: 1
+  terraform-provider-release:
+    name: 'Terraform Provider Release'
+    needs: [go-version, release-notes]
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v1
+    secrets:
+      hc-releases-aws-access-key-id: '${{ secrets.TF_PROVIDER_RELEASE_AWS_ACCESS_KEY_ID }}'
+      hc-releases-aws-secret-access-key: '${{ secrets.TF_PROVIDER_RELEASE_AWS_SECRET_ACCESS_KEY }}'
+      hc-releases-aws-role-arn: '${{ secrets.TF_PROVIDER_RELEASE_AWS_ROLE_ARN }}'
+      hc-releases-fastly-api-token: '${{ secrets.HASHI_FASTLY_PURGE_TOKEN }}'
+      hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
+      hc-releases-terraform-registry-sync-token: '${{ secrets.TF_PROVIDER_RELEASE_TERRAFORM_REGISTRY_SYNC_TOKEN }}'
+      setup-signore-github-token: '${{ secrets.HASHI_SIGNORE_GITHUB_TOKEN }}'
+      signore-client-id: '${{ secrets.SIGNORE_CLIENT_ID }}'
+      signore-client-secret: '${{ secrets.SIGNORE_CLIENT_SECRET }}'
+    with:
+      release-notes: true
+      setup-go-version: '${{ needs.go-version.outputs.version }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ publishers:
     # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
     # For providers which have existed since those CLI versions, exclude
     # discovery by setting the protocol version headers to 5.
-    cmd: hc-releases upload-file {{ abs .ArtifactPath }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
+    cmd: hc-releases upload-file {{ abs .ArtifactPath }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0 -upload-name={{ .ArtifactName }}
     env:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,75 @@
+archives:
+  - files:
+      # Ensure only built binary is archived
+      - 'none*'
+    format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+before:
+  hooks:
+    - 'go mod download'
+builds:
+  - # Binary naming only required for Terraform CLI 0.12
+    binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    goarch:
+      - '386'
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goarch: arm
+        goos: windows
+      - goarch: arm64
+        goos: freebsd
+      - goarch: arm64
+        goos: windows
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+checksum:
+  algorithm: sha256
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+publishers:
+  - checksum: true
+    # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
+    # For providers which have existed since those CLI versions, exclude
+    # discovery by setting the protocol version headers to 5.
+    cmd: hc-releases upload-file {{ abs .ArtifactPath }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
+    env:
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
+    extra_files:
+      - glob: 'terraform-registry-manifest.json'
+        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+    name: hc-releases
+    signature: true
+release:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  ids:
+    - none
+signs:
+  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+    artifacts: checksum
+    cmd: signore
+    signature: ${artifact}.sig
+  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+    artifacts: checksum
+    cmd: signore
+    id: key-id
+    signature: ${artifact}.72D7468F.sig
+snapshot:
+  name_template: "{{ .Tag }}-next"

--- a/.tfproto5
+++ b/.tfproto5
@@ -1,1 +1,0 @@
-Protocol 5.0 only

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "metadata": {
+        "protocol_versions": ["5.0"]
+    }
+}


### PR DESCRIPTION
Internal RFC References:

* ENGSRV-035
* ENGSRV-064
* SEC-036
* SEC-061
* TF-279

_Please note: This process can be adjusted to suit your needs, but it will require changes to the workflow setup._

The initial release workflow submitted here is triggered by pushing a semantic version tag prepended with a `v` to the repository. For example:

```shell
git switch main # or your release branch
git pull
git tag v1.2.3
git push origin v1.2.3
```

The most important distinction from the TeamCity release process is that the repository must be fully prepared for the release, including the `CHANGELOG.md` file. Providers can decide the most appropriate process to manage the CHANGELOG or any release notes as part of this new process. This initial workflow will automatically grab contents from the top of the CHANGELOG through the previous release tag header line. [Example provider CHANGELOG](https://github.com/hashicorp/terraform-provider-tls/blob/156ae39c7e55ee8597f859a77ae2db739527376b/CHANGELOG.md) and its [GitHub Release description](https://github.com/hashicorp/terraform-provider-tls/releases/tag/v3.3.0).

Please reach out if you have questions.